### PR TITLE
Implement Makeable feature

### DIFF
--- a/src/NovaSidebar.php
+++ b/src/NovaSidebar.php
@@ -2,11 +2,14 @@
 
 namespace Giuga\LaravelNovaSidebar;
 
+use Giuga\LaravelNovaSidebar\Traits\Makeable;
 use Illuminate\Support\Collection;
 use Laravel\Nova\Tool;
 
 class NovaSidebar extends Tool
 {
+    use Makeable;
+
     public Collection $linkGroups;
     public Collection $links;
 

--- a/src/SidebarGroup.php
+++ b/src/SidebarGroup.php
@@ -2,10 +2,13 @@
 
 namespace Giuga\LaravelNovaSidebar;
 
+use Giuga\LaravelNovaSidebar\Traits\Makeable;
 use Illuminate\Support\Collection;
 
 class SidebarGroup
 {
+    use Makeable;
+
     public string $name;
     public Collection $links;
 

--- a/src/SidebarLink.php
+++ b/src/SidebarLink.php
@@ -2,8 +2,12 @@
 
 namespace Giuga\LaravelNovaSidebar;
 
+use Giuga\LaravelNovaSidebar\Traits\Makeable;
+
 class SidebarLink
 {
+    use Makeable;
+
     public string $url;
     public string $type = '_blank';
     public string $name;

--- a/src/Traits/Makeable.php
+++ b/src/Traits/Makeable.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Giuga\LaravelNovaSidebar\Traits;
+
+trait Makeable
+{
+    /**
+     * Create a new element.
+     *
+     * @return static
+     */
+    public static function make(...$arguments)
+    {
+        return new static(...$arguments);
+    }
+}

--- a/tests/MakeableTest.php
+++ b/tests/MakeableTest.php
@@ -5,13 +5,10 @@ namespace Giuga\LaravelNovaSidebar\Tests;
 use Giuga\LaravelNovaSidebar\NovaSidebar;
 use Giuga\LaravelNovaSidebar\SidebarGroup;
 use Giuga\LaravelNovaSidebar\SidebarLink;
-use Illuminate\Support\Collection;
-use Laravel\Nova\Tool;
 use Orchestra\Testbench\TestCase;
 
 class MakeableTest extends TestCase
 {
-
     /** @test */
     public function testNovaSidebarIsMakeable()
     {
@@ -32,5 +29,4 @@ class MakeableTest extends TestCase
         $sidebarLink = SidebarLink::make();
         $this->assertTrue($sidebarLink instanceof SidebarLink);
     }
-
 }

--- a/tests/MakeableTest.php
+++ b/tests/MakeableTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Giuga\LaravelNovaSidebar\Tests;
+
+use Giuga\LaravelNovaSidebar\NovaSidebar;
+use Giuga\LaravelNovaSidebar\SidebarGroup;
+use Giuga\LaravelNovaSidebar\SidebarLink;
+use Illuminate\Support\Collection;
+use Laravel\Nova\Tool;
+use Orchestra\Testbench\TestCase;
+
+class MakeableTest extends TestCase
+{
+
+    /** @test */
+    public function testNovaSidebarIsMakeable()
+    {
+        $novaSidebar = NovaSidebar::make();
+        $this->assertTrue($novaSidebar instanceof NovaSidebar);
+    }
+
+    /** @test */
+    public function testSidebarGroupIsMakeable()
+    {
+        $sidebarGroup = SidebarGroup::make();
+        $this->assertTrue($sidebarGroup instanceof SidebarGroup);
+    }
+
+    /** @test */
+    public function testSidebarLinkIsMakeable()
+    {
+        $sidebarLink = SidebarLink::make();
+        $this->assertTrue($sidebarLink instanceof SidebarLink);
+    }
+
+}


### PR DESCRIPTION
In more recent Nova version there is a Trait allowing method chaining by the use of static method make().
This PR implement it for the package.

Example:
This
```
 (new NovaSidebar())
            ->addGroup((new SidebarGroup())
            ->setName('Utilities')
```
may become this
```
NovaSidebar::make()
            ->addGroup((new SidebarGroup())
            ->setName('Utilities')
```

The Makeable trait is a copy from recent Nova versions as I did not want to bump up the nova version required to make it avaible.